### PR TITLE
Adds an index.ts file to the generated library for easy use of all types

### DIFF
--- a/_templates/index.ejs
+++ b/_templates/index.ejs
@@ -1,0 +1,19 @@
+/* eslint-disable*/
+<%_ EntityTypes.forEach(function(e){_%>
+export { <%-e.Name%>Metadata } from "./entities/<%-e.SchemaName%>";
+export { <%-e.Name%> } from "./entities/<%-e.SchemaName%>";
+<%_})_%>
+<%_ EnumTypes.forEach(function(e){_%>
+export { <%-e.Name%> } from "./enums/<%-e.SchemaName%>";
+<%_})_%>
+<%_ Actions.forEach(function(e){_%>
+export { <%-e.Name%>Metadata } from "./actions/<%-e.Name%>";
+export { <%-e.Name%>Request } from "./actions/<%-e.Name%>";
+<%_})_%>
+<%_ Functions.forEach(function(e){_%>
+export { <%-e.Name%>Metadata } from "./functions/<%-e.Name%>";
+export { <%-e.Name%> } from "./functions/<%-e.Name%>";
+<%_})_%>
+<%_ ComplexTypes.forEach(function(e){_%>
+export { <%-e.Name%> } from "./complextypes/<%-e.Name%>";
+<%_})_%>

--- a/src/TypescriptGenerator.ts
+++ b/src/TypescriptGenerator.ts
@@ -57,6 +57,9 @@ export class TypescriptGenerator {
     this.outputFiles("metadata.ejs", ".", [{ ...schema, ...this.options }], function() {
       return "metadata";
     });
+    this.outputFiles("index.ejs", ".", [{ ...schema, ...this.options }], function() {
+      return "index";
+    });
   }
 
   createDir(dirPath: string): void {


### PR DESCRIPTION
With the addition of the `index.ts` file users can now use any type provided by this library without needing to import a specific sub-module.

For example:

```
import { Account } from './dataverse-gen';
```

vs

```
import { Account } from './dataverse-gen/entities/Account';
```

This is useful because it decreases the knowledge necessary and allows all exports to be exposed and browsed from a single file so future developers can easily understand the full scope of what is available.