### PR TITLE
Field overrides for getAttribute and getControl

### DIFF
--- a/_templates/entity.ejs
+++ b/_templates/entity.ejs
@@ -1,5 +1,30 @@
 /* eslint-disable*/
 import { <%-referencedTypes["Entity"].name%> } from "<%-referencedTypes["Entity"].import%>";
+
+// Entity <%- locals.SchemaName %> FormContext
+export interface <%- SchemaName %>FormContext extends Xrm.FormContext {
+    getAttribute(): Xrm.Attributes.Attribute[];
+    getAttribute<T extends Xrm.Attributes.Attribute>(attributeName: string): T;
+    getAttribute(attributeName: string): Xrm.Attributes.Attribute;
+    getAttribute(index: number): Xrm.Attributes.Attribute;
+
+    getControl(): Xrm.Controls.Control[];
+    getControl<T extends Xrm.Controls.Control>(controlName: string): T;
+    getControl(controlName: string): Xrm.Controls.Control;
+    getControl(index: number): Xrm.Controls.Control;
+
+  <%locals.Properties && locals.Properties.forEach(function(property){ if(!property.AttributeOf && property.SourceType === 0 && property.TypescriptType.name !== 'Guid' && property.TypescriptType.definitelyTypedAttributeType) { _%>
+  /**
+    * <%- property.Description %>
+    */
+    getAttribute(name: '<%- property.Name %>'): <%-property.TypescriptType.definitelyTypedAttributeType%>;
+  /**
+  * <%- property.Description %>
+    */
+    getControl(name: '<%- property.Name %>'): <%-property.TypescriptType.definitelyTypedControlType%>;
+  <%}})_%>
+}
+
 // Entity <%- locals.SchemaName %>
 export const <%- Name %>Metadata = {
   typeName: "mscrm.<%- Name %>",

--- a/src/EdmxTypes.ts
+++ b/src/EdmxTypes.ts
@@ -19,6 +19,8 @@ export interface EntityTypeProperty {
   DisplayName: string;
   Description: string;
   IsEnum: boolean;
+  AttributeOf?: string;
+  SourceType?: number;
 }
 
 export interface EntityTypeNavigationProperty {
@@ -33,6 +35,7 @@ export interface EntityTypeNavigationProperty {
   IsCollection?: boolean;
   ReferentialConstraint?: string;
   ReferencedProperty?: string;
+  definitelyTypedType?: string;
 }
 
 export interface EntityType extends EdmxBase {

--- a/src/SchemaModel.ts
+++ b/src/SchemaModel.ts
@@ -230,6 +230,8 @@ export class SchemaModel {
       DisplayName: attribute.DisplayName?.UserLocalizedLabel ? attribute.DisplayName.UserLocalizedLabel.Label : "",
       Format: dateFormat,
       IsMultiSelect: multiSelect,
+      AttributeOf: attribute.AttributeOf,
+      SourceType: attribute.SourceType
     } as EntityTypeProperty;
   }
 
@@ -435,6 +437,7 @@ export class SchemaModel {
     const isMultiSelect = property.IsMultiSelect;
     const isCollection = this.isCollection(referencedType);
     const typeName = this.removeCollection(referencedType);
+    let definitelyTypedFieldType: string | undefined;
     let type = "any";
 
     switch (typeName) {
@@ -445,6 +448,7 @@ export class SchemaModel {
       case "StateType":
       case "StatusType":
         type = "number";
+        definitelyTypedFieldType = "OptionSet";
         break;
       case "Edm.Guid":
       case "UniqueidentifierType":
@@ -459,6 +463,7 @@ export class SchemaModel {
       case "MemoType":
       case "EntityNameType":
         type = "string";
+        definitelyTypedFieldType = "String";
         break;
       case "Edm.Int16":
       case "Edm.Int32":
@@ -471,22 +476,27 @@ export class SchemaModel {
       case "DecimalType":
       case "MoneyType":
         type = "number";
+        definitelyTypedFieldType = "Number";
         break;
       case "Edm.Boolean":
       case "BooleanType":
         type = "boolean";
+        definitelyTypedFieldType = "Boolean";
         break;
       case "Edm.DateTimeOffset":
       case "DateTimeType":
         type = "Date";
+        definitelyTypedFieldType = "Date"
         break;
       case "CustomerType":
       case "LookupType":
       case "OwnerType":
         type = "EntityReference";
+        definitelyTypedFieldType = "Lookup";
         break;
       case "PartyListType":
         type = "ActivityParty[]";
+        definitelyTypedFieldType = "OptionSet";
         break;
       case "ManagedPropertyType":
         type = "number";
@@ -530,6 +540,8 @@ export class SchemaModel {
       name: type,
       outputType: outputType,
       importLocation: this.resolveTypeToImportLocation(type, outputType),
+      definitelyTypedAttributeType: property.IsEnum ? "Xrm.Attributes.OptionSetAttribute" : `Xrm.Attributes.${definitelyTypedFieldType}Attribute`,
+      definitelyTypedControlType: property.IsEnum || property.Type == "BooleanType" ? "Xrm.Controls.OptionSetControl" : `Xrm.Controls.${definitelyTypedFieldType}Control`
     } as TypeScriptType;
   }
 


### PR DESCRIPTION
Updated ejs template to add overrides for each attribute and control on entity level. Not all attributes/controls will have this though e.g. multi-select option set.